### PR TITLE
Fix inncorectly ser truncated value.

### DIFF
--- a/ptrace/debugger/process.py
+++ b/ptrace/debugger/process.py
@@ -662,7 +662,7 @@ class PtraceProcess(object):
             if max_size <= size + chunk_length:
                 data = data[:(max_size - size)]
                 string.append(data)
-                truncated = True
+                truncated = (pos == -1)
                 break
             string.append(data)
             if done:


### PR DESCRIPTION
In cases when \0 was found at index position less than max_size,
`truncated` should be False.

Maybe 'if' condition could be also changed, but I wanted to keep it small.