### PR TITLE
memory map device ids can be like (xxx:xx) for me, but the regex only…

### DIFF
--- a/ptrace/debugger/memory_mapping.py
+++ b/ptrace/debugger/memory_mapping.py
@@ -15,7 +15,7 @@ PROC_MAP_REGEX = re.compile(
     # Offset: '0804d000'
     r'([0-9a-f]+) '
     # Device (major:minor): 'fe:01 '
-    r'([0-9a-f]{2}):([0-9a-f]{2}) '
+    r'([0-9a-f]{2,3}):([0-9a-f]{2}) '
     # Inode: '3334030'
     r'([0-9]+)'
     # Filename: '  /usr/bin/synergyc'


### PR DESCRIPTION
… allowed precisely (xx:xx)

This fixes a failing test for me:

```
$ ./runtests.py 
..........F....
======================================================================
FAIL: test_maps (test_gdb.TestGdb)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/test_gdb.py", line 71, in test_maps
    self.check_stdout(b'^MAPS: ', stdout)
  File "tests/test_gdb.py", line 39, in check_stdout
    (pattern, stdout))
AssertionError: ('^MAPS: ', "Command error: Unable to parse memory mapping: '55dd25185000-55dd251d3000 r--p 00000000 103:03 11141620                  /usr/bin/python2.7'\nERROR: Unable to parse memory mapping: '55dd25185000-55dd251d3000 r--p 00000000 103:03 11141620                  /usr/bin/python2.7'")

----------------------------------------------------------------------
Ran 15 tests in 1.454s

FAILED (failures=1)
```

Specifically,

```
$ ./gdb.py ls
(gdb) maps
Command error: Unable to parse memory mapping: '557409c0e000-557409c12000 r--p 00000000 103:03 2490530                   /bin/ls'
ERROR: Unable to parse memory mapping: '557409c0e000-557409c12000 r--p 00000000 103:03 2490530                   /bin/ls'
``` 

With this change on my computer

```
$ ./gdb.py ls
(gdb) maps
MAPS: 0x0000563440475000-0x0000563440479000 => /bin/ls (r--p)
MAPS: 0x0000563440479000-0x000056344048c000 => /bin/ls (r-xp)
MAPS: 0x000056344048c000-0x0000563440495000 => /bin/ls (r--p)
MAPS: 0x0000563440496000-0x0000563440498000 => /bin/ls (rw-p)
MAPS: 0x0000563440498000-0x0000563440499000 (rw-p)
MAPS: 0x00007fcea3df9000-0x00007fcea3dfa000 => /lib/x86_64-linux-gnu/ld-2.29.so (r--p)
MAPS: 0x00007fcea3dfa000-0x00007fcea3e1b000 => /lib/x86_64-linux-gnu/ld-2.29.so (r-xp)
MAPS: 0x00007fcea3e1b000-0x00007fcea3e23000 => /lib/x86_64-linux-gnu/ld-2.29.so (r--p)
MAPS: 0x00007fcea3e23000-0x00007fcea3e25000 => /lib/x86_64-linux-gnu/ld-2.29.so (rw-p)
MAPS: 0x00007fcea3e25000-0x00007fcea3e26000 (rw-p)
MAPS: 0x00007ffea2443000-0x00007ffea2464000 => [stack] (rw-p)
MAPS: 0x00007ffea24f4000-0x00007ffea24f7000 => [vvar] (r--p)
MAPS: 0x00007ffea24f7000-0x00007ffea24f8000 => [vdso] (r-xp)
MAPS: 0xffffffffff600000-0xffffffffff601000 => [vsyscall] (r-xp)
```

```
./runtests.py 
...............
----------------------------------------------------------------------
Ran 15 tests in 1.459s

OK
```
