### PR TITLE
File descriptors handling

### DIFF
--- a/ptrace/debugger/child.py
+++ b/ptrace/debugger/child.py
@@ -12,7 +12,6 @@ from ptrace.binding import ptrace_traceme
 from ptrace import PtraceError
 from sys import exit
 from errno import EINTR
-from logging import warning
 import fcntl
 import pickle
 
@@ -155,10 +154,8 @@ def createChild(arguments, no_stdout, env=None, close_fds=True, pass_fds=()):
      - env=None (default) to copy the environment
     """
 
-    if not RUNNING_WINDOWS:
-        if pass_fds and not close_fds:
-            warning("pass_fds overriding close_fds.")
-            close_fds = True
+    if pass_fds and not close_fds:
+        close_fds = True
 
     errpipe_read, errpipe_write = pipe()
     _set_cloexec_flag(errpipe_write)

--- a/ptrace/debugger/child.py
+++ b/ptrace/debugger/child.py
@@ -4,7 +4,7 @@ Error pipe and serialization code comes from Python 2.5 subprocess module.
 from os import (
     fork, execvp, execvpe, waitpid,
     close, dup2, pipe,
-    read, write, devnull, sysconf)
+    read, write, devnull, sysconf, set_inheritable)
 from sys import exc_info
 from traceback import format_exception
 from ptrace.os_tools import RUNNING_WINDOWS
@@ -99,6 +99,9 @@ def _createChild(arguments,
         ptrace_traceme()
     except PtraceError as err:
         raise ChildError(str(err))
+
+    for fd in pass_fds:
+        set_inheritable(fd, True)
 
     if close_fds:
         # Close all files except 0, 1, 2 and errpipe_write


### PR DESCRIPTION
Copied the `subprocess.Popen` API, with `close_fds` and `pass_fds` flags at child creation. For #54.