### PR TITLE
FIX: port ptrace/profiler.py to python3

### DIFF
--- a/ptrace/profiler.py
+++ b/ptrace/profiler.py
@@ -1,23 +1,35 @@
-from hotshot import Profile
-from hotshot.stats import load as loadStats
+from profile import Profile
 from os import unlink
 from io import StringIO
+import pstats
+
+
+def calibrate(n):
+    """
+    https://docs.python.org/3/library/profile.html#calibration
+    """
+    if n > 0:
+        pr = Profile()
+        magics = []
+        for i in range(n):
+            magics.append(pr.calibrate(10000))
+        return sum(magics) / n
 
 
 def runProfiler(logger, func, args=tuple(), kw={},
                 verbose=True, nb_func=25,
-                sort_by=('time',)):
+                sort_by=('time',), calibration=5):
     """
     Run a function in a profiler and then display the functions sorted by time.
     """
     profile_filename = "/tmp/profiler"
-    prof = Profile(profile_filename)
+    prof = Profile(bias=calibrate(calibration))
     try:
         logger.warning("Run profiler")
         result = prof.runcall(func, *args, **kw)
-        prof.close()
         logger.error("Profiler: Process data...")
-        stat = loadStats(profile_filename)
+        prof.dump_stats(profile_filename)
+        stat = pstats.Stats(prof)
         stat.strip_dirs()
         stat.sort_stats(*sort_by)
 

--- a/ptrace/profiler.py
+++ b/ptrace/profiler.py
@@ -18,12 +18,12 @@ def calibrate(n):
 
 def runProfiler(logger, func, args=tuple(), kw={},
                 verbose=True, nb_func=25,
-                sort_by=('time',), calibration=5):
+                sort_by=('time',), nb_cal=0):
     """
     Run a function in a profiler and then display the functions sorted by time.
     """
     profile_filename = "/tmp/profiler"
-    prof = Profile(bias=calibrate(calibration))
+    prof = Profile(bias=calibrate(nb_cal))
     try:
         logger.warning("Run profiler")
         result = prof.runcall(func, *args, **kw)


### PR DESCRIPTION
Replace deprecated python2 [hotshot](https://docs.python.org/2/library/profile.html) module.