### PR TITLE
FIX SyscallState wait at exit()

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -9,6 +9,7 @@ python-ptrace 0.9.8
 * Added Arm 64bit (AArch64) support.
 * Implemented PTRACE_GETREGSET and PTRACE_SETREGSET required on AArch64 and
   available on Linux.
+* Issue #66: Fix SIGTRAP|0x80 or SIGTRAP wait in syscall_state.exit (PTRACE_O_TRACESYSGOOD)
 
 python-ptrace 0.9.7 (2020-08-10)
 --------------------------------

--- a/ptrace/debugger/syscall_state.py
+++ b/ptrace/debugger/syscall_state.py
@@ -1,5 +1,4 @@
 from ptrace.syscall import PtraceSyscall
-from signal import SIGTRAP
 
 
 class SyscallState(object):
@@ -37,7 +36,7 @@ class SyscallState(object):
                 and not self.process.debugger.trace_exec:
             # Ignore the SIGTRAP after exec() syscall exit
             self.process.syscall()
-            self.process.waitSignals(SIGTRAP)
+            self.process.waitSyscall()
         syscall = self.syscall
         self.clear()
         return syscall


### PR DESCRIPTION
Solves issue https://github.com/vstinner/python-ptrace/issues/66.
See https://github.com/vstinner/python-ptrace/issues/66#issuecomment-772821252 for details, thanks to @spoutn1k for investigating the issue.

When `PTRACE_O_TRACESYSGOOD` is set, the process should wait for `SIGTRAP|0x80`, not `SIGTRAP` upon exit of a syscall.