### PR TITLE
FIX: 68833a9 which failed a simple $ strace.py -- bash -c "ls"

### DIFF
--- a/ptrace/debugger/process.py
+++ b/ptrace/debugger/process.py
@@ -733,7 +733,7 @@ class PtraceProcess(object):
         return self.debugger.waitProcessEvent(pid=self.pid)
 
     def waitSignals(self, *signals):
-        return self.debugger.waitSignals(*signals, **{'pid': self.pid})
+        return self.debugger.waitSignals(*signals, pid=self.pid)
 
     def waitSyscall(self):
         self.debugger.waitSyscall(self)

--- a/ptrace/debugger/syscall_state.py
+++ b/ptrace/debugger/syscall_state.py
@@ -1,4 +1,5 @@
 from ptrace.syscall import PtraceSyscall
+from signal import SIGTRAP
 
 
 class SyscallState(object):
@@ -36,7 +37,7 @@ class SyscallState(object):
                 and not self.process.debugger.trace_exec:
             # Ignore the SIGTRAP after exec() syscall exit
             self.process.syscall()
-            self.process.waitSyscall()
+            self.process.waitSignals(SIGTRAP, SIGTRAP | 0x80)
         syscall = self.syscall
         self.clear()
         return syscall


### PR DESCRIPTION
68833a9e6fd9ee6353a3a1c9c7a65b2fe300991f failed the following:
```bash
$ strace.py -- bash -c "ls"
```
