### PR TITLE
Fix PROC_MAP_REGEX for three digit minor device id

### DIFF
--- a/ptrace/debugger/memory_mapping.py
+++ b/ptrace/debugger/memory_mapping.py
@@ -15,7 +15,7 @@ PROC_MAP_REGEX = re.compile(
     # Offset: '0804d000'
     r'([0-9a-f]+) '
     # Device (major:minor): 'fe:01 '
-    r'([0-9a-f]{2,3}):([0-9a-f]{2}) '
+    r'([0-9a-f]{2,3}):([0-9a-f]{2,3}) '
     # Inode: '3334030'
     r'([0-9]+)'
     # Filename: '  /usr/bin/synergyc'


### PR DESCRIPTION
Hi,

I encountered process mappings with three digit minor device IDs while emulating an Android ELF with QEMU:
```
400180e000-400191d000 r--p 00000000 00:166 103288                        /path/to/system/bin/linker64
```

This PR fixes the regex to correctly parse the mappings file.