### PR TITLE
Fix arguments of pipe/pipe2 system calls.

### DIFF
--- a/SYSCALL_PROTOTYPES.codegen.py
+++ b/SYSCALL_PROTOTYPES.codegen.py
@@ -32,6 +32,9 @@ for m1 in p1.finditer(source):
                 m2 = p2.match(arg)
                 arg_type = m2.group(1).strip()
                 arg_name = m2.group(2).strip()
+            # Workaround for pipe system call
+            if (call_name == 'pipe' or call_name == 'pipe2') and arg_type == "int *":
+                arg_type = "int[2]"
             args_tuple += ((arg_type, arg_name),)
     SYSCALL_PROTOTYPES[call_name] = ("long", args_tuple)
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -6,6 +6,8 @@ Changelog
 python-ptrace 0.9.9
 --------------------------------
 
+* Fix arguments of pipe/pipe2 system calls for proper display in call format.
+  Patch by José Pereira.
 * Introduced support for three-digit minor device IDs in ``PROC_MAP_REGEX``.
   Patch by fab1ano.
 * Added RISCV (riscv32/riscv64) support.

--- a/ptrace/syscall/prototypes.py
+++ b/ptrace/syscall/prototypes.py
@@ -962,10 +962,10 @@ SYSCALL_PROTOTYPES = {
         ("unsigned int", "personality"),
     )),
     "pipe": ("long", (
-        ("int *", "fildes"),
+        ("int[2]", "fildes"),
     )),
     "pipe2": ("long", (
-        ("int *", "fildes"),
+        ("int[2]", "fildes"),
         ("int", "flags"),
     )),
     "pivot_root": ("long", (


### PR DESCRIPTION
The first argument of pipe/pipe2 system calls needs to be declared as int[2] instead of int* to display both file descriptors.