### PR TITLE
do not raise an exception for a valid process status

### DIFF
--- a/ptrace/process_tools.py
+++ b/ptrace/process_tools.py
@@ -106,9 +106,6 @@ def formatProcessStatus(status, title="Process"):
         signum = WTERMSIG(status)
         text = "%s killed by signal %s" % (title, signalName(signum))
     else:
-        if not WIFEXITED(status):
-            raise ValueError("Invalid status: %r" % status)
-
         exitcode = WEXITSTATUS(status)
         if exitcode:
             text = "%s exited with code %s" % (title, exitcode)


### PR DESCRIPTION
On Linux traced processes can return a status of "255"; this is not invalid and should not cause the tracer "strace.py" to abort.  This fix may be naive of other OS implementations of os.WIFEXITED(), I am unable to test on Windows or MacOS.